### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/OSGI/edge-ml-welding-sound/src/edge/pom.xml
+++ b/OSGI/edge-ml-welding-sound/src/edge/pom.xml
@@ -16,14 +16,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832