### PR TITLE
Remove custom extensions flag

### DIFF
--- a/IoT_Edge/persistence-service-ref-app/assemble/helm/persistence-ref-app/templates/statefulset.yaml
+++ b/IoT_Edge/persistence-service-ref-app/assemble/helm/persistence-ref-app/templates/statefulset.yaml
@@ -40,8 +40,6 @@ spec:
                     value: "{{ required "A valid value is required for loadTestProtocol" .Values.loadTestProtocol }}"
                   - name: MAX_IN_FLIGHT
                     value: "{{ required "A valid value is required for max in flight" .Values.maxInFlight  }}"
-                  - name: CUSTOM_EXTENSION
-                    value: "true"
                   - name: SERVICE_BINDINGS
                     value: {{ required "A valid value is required for serviceBindings" .Values.serviceBindings | quote }}
             imagePullSecrets:


### PR DESCRIPTION
Fixing the helm chart
This flag was initially introduced due to an internal bug which prevented envoy filter to inject authorization header